### PR TITLE
Force `canonical()` to use the Twig _function_.

### DIFF
--- a/templates/rss.twig
+++ b/templates/rss.twig
@@ -2,7 +2,7 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
     <channel>
         <title>{{ app.config.get('general/sitename') }}</title>
-        <atom:link href="{{ canonical }}" rel="self" type="application/rss+xml"/>
+        <atom:link href="{{ canonical() }}" rel="self" type="application/rss+xml"/>
         <link>{{ url('homepage') }}</link>
 {% if app.config.get('general/payoff') is defined %}
         <description>{{ app.config.get('general/payoff') }}</description>


### PR DESCRIPTION
Fixes #23 