### PR TITLE
Feature: feed per category (Fixes #22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ RSS, JSON and Atom feed publisher
 Creates sitewide and/or contenttype specific feeds for your Bolt website.
 
 After installation, a configuration file will be created as
-`app/config/extensions/rssfeed.bolt.yml`, where you can define how the various 
-feeds should be created. Depending on your set up in the extension's 
-configuration, you can access RSS feeds either by sitewide or contenttype 
+`app/config/extensions/rssfeed.bolt.yml`, where you can define how the various
+feeds should be created. Depending on your set up in the extension's
+configuration, you can access RSS feeds either by sitewide or contenttype
 specific URLs:
 
  - **Site wide**: `/rss/feed.{extension}`
@@ -34,3 +34,22 @@ my_rss_feed:
         _controller: controller.rssfeed:feed
         contenttypeslug: news
 ```
+
+Taxonomy filters
+----------------
+
+You can apply a taxonomy filter as a query string to your feeds, like so:
+
+```
+?filter[taxonomyname]=slug
+```
+
+For example:
+
+```
+?filter[categories]=movies
+?filter[groups]=meta
+?filter[tags]=cinema
+```
+
+This only works for at most one filter and only for taxonomies.

--- a/src/Controller/RssFeed.php
+++ b/src/Controller/RssFeed.php
@@ -63,7 +63,8 @@ class RssFeed implements ControllerProviderInterface
      */
     public function atom(Application $app, $contentTypeName = null)
     {
-        $atom = $app['rssfeed.generator']->getAtom($contentTypeName);
+        $filter = $app['request']->query->get('filter', []);
+        $atom = $app['rssfeed.generator']->getAtom($contentTypeName, $filter);
 
         $response = new Response($atom, Response::HTTP_OK);
         $response->setCharset('utf-8')
@@ -83,7 +84,8 @@ class RssFeed implements ControllerProviderInterface
      */
     public function feed(Application $app, $contentTypeName = null)
     {
-        $feed = $app['rssfeed.generator']->getFeed($contentTypeName);
+        $filter = $app['request']->query->get('filter', []);
+        $feed = $app['rssfeed.generator']->getFeed($contentTypeName, $filter);
 
         $response = new Response($feed, Response::HTTP_OK);
         $response->setCharset('utf-8')
@@ -103,7 +105,8 @@ class RssFeed implements ControllerProviderInterface
      */
     public function json(Application $app, $contentTypeName = null)
     {
-        $json = $app['rssfeed.generator']->getJson($contentTypeName);
+        $filter = $app['request']->query->get('filter', []);
+        $json = $app['rssfeed.generator']->getJson($contentTypeName, $filter);
 
         // Put our own JSON together, instead of using JSONResponse, because pretty printing is nice.
         $json = json_encode($json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);

--- a/src/RssFeedExtension.php
+++ b/src/RssFeedExtension.php
@@ -38,7 +38,8 @@ class RssFeedExtension extends SimpleExtension
                     $app['twig'],
                     $app['url_generator'],
                     $app['config']->get('general/sitename'),
-                    $app['config']->get('general/payoff')
+                    $app['config']->get('general/payoff'),
+                    $app['config']->get('general/database/prefix')
                 );
             }
         );


### PR DESCRIPTION
Fixes #22 

Allows for a simple taxonomy filter, by query-ing something like:

```
?filter[categories]=movies
```

- only works for taxonomies; filter does not work for fields or whatever.
- only works for one taxonomy filter; the first key-value combination is used, all others are ignored.