### PR TITLE
Allow blockquote and cite elements in feeds

### DIFF
--- a/src/ParseContent.php
+++ b/src/ParseContent.php
@@ -34,7 +34,7 @@ class ParseContent {
         $maid = new Maid(
             [
                 'output-format'   => 'html',
-                'allowed-tags'    => ['a', 'b', 'br', 'div', 'hr', 'h1', 'h2', 'h3', 'h4', 'p', 'strong', 'em', 'i', 'u', 'strike', 'ul', 'ol', 'li', 'img'],
+                'allowed-tags'    => ['a', 'b', 'br', 'div', 'hr', 'h1', 'h2', 'h3', 'h4', 'p', 'strong', 'em', 'i', 'u', 'strike', 'ul', 'ol', 'li', 'img', 'blockquote', 'cite'],
                 'allowed-attribs' => ['id', 'class', 'name', 'value', 'href', 'src'],
             ]
         );


### PR DESCRIPTION
I contemplated adding `dl` and the relevant child elements, as well, but those might be more rare.